### PR TITLE
Set default of "git_setup" to yes

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,5 +8,5 @@
     "organization_name": "weldx.bam.de",
     "schema_uri_root": "http://weldx.bam.de/schemas/weldx",
     "manifest_uri_root": "http://weldx.bam.de/weldx/extensions/manifests",
-    "git_setup": ["no", "yes"]
+    "git_setup": ["yes", "no"]
 }


### PR DESCRIPTION
Set the default selection of "git_setup" to "yes" since the repo can't be installed without any modifications if "no" is selected (Version is extracted from git).